### PR TITLE
Move allocator from rboehm

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+set -e
+
+export CARGO_HOME="`pwd`/.cargo"
+export RUSTUP_HOME="`pwd`/.rustup"
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+sh rustup.sh --default-host x86_64-unknown-linux-gnu \
+    --default-toolchain nightly \
+    --no-modify-path \
+    --profile minimal \
+    -y
+export PATH=`pwd`/.cargo/bin/:$PATH
+cargo check
+
+rustup toolchain install nightly --allow-downgrade --component rustfmt
+cargo +nightly fmt --all -- --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,18 @@
 [package]
-name = "boehm_allocator"
+name = "libgc_internal"
 version = "0.1.0"
 authors = ["Jacob Hughes <jh@jakehughes.uk>"]
 edition = "2018"
 
+[lib]
+test = false
+bench = false
+doc = false
+
 [features]
 # Enable this feature to turn on additional GC optimizations that are only
-# possible with the rustc_boehm fork of the compiler.
-rustc_boehm = ["core", "compiler_builtins"]
+# possible with the rustgc fork of the compiler.
+rustgc = ["core", "compiler_builtins"]
 
 # Enable various GC based statistics. Stats are disabled by default as they have
 # a run-time cost and are expected to only be used for profiling purposes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "boehm_allocator"
+version = "0.1.0"
+authors = ["Jacob Hughes <jh@jakehughes.uk>"]
+edition = "2018"
+
+[features]
+# Enable this feature to turn on additional GC optimizations that are only
+# possible with the rustc_boehm fork of the compiler.
+rustc_boehm = ["core", "compiler_builtins"]
+
+# Enable various GC based statistics. Stats are disabled by default as they have
+# a run-time cost and are expected to only be used for profiling purposes.
+gc_stats = []
+
+
+[dependencies]
+core = { version = "1.0.0", optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = "0.1.10", optional = true, features = ['rustc-dep-of-std'] }
+

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,6 @@
+status = ["buildbot/buildbot-build-script"]
+
+timeout_sec = 600 # 10 minutes
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,65 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+const BOEHM_REPO: &str = "https://github.com/ivmai/bdwgc.git";
+const BOEHM_ATOMICS_REPO: &str = "https://github.com/ivmai/libatomic_ops.git";
+const BOEHM_DIR: &str = "bdwgc";
+const BUILD_DIR: &str = ".libs";
+
+#[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
+compile_error!("Requires x86_64 with 64 bit pointer width.");
+static POINTER_MASK: &str = "-DPOINTER_MASK=0xFFFFFFFFFFFFFFF8";
+static FPIC: &str = "-fPIC";
+
+fn run<F>(name: &str, mut configure: F)
+where
+    F: FnMut(&mut Command) -> &mut Command,
+{
+    let mut command = Command::new(name);
+    let configured = configure(&mut command);
+    if !configured.status().is_ok() {
+        panic!("failed to execute {:?}", configured);
+    }
+}
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let mut boehm_src = PathBuf::from(out_dir);
+    boehm_src.push(BOEHM_DIR);
+
+    if !boehm_src.exists() {
+        run("git", |cmd| {
+            cmd.arg("clone").arg(BOEHM_REPO).arg(&boehm_src)
+        });
+
+        run("git", |cmd| {
+            cmd.arg("clone")
+                .arg(BOEHM_ATOMICS_REPO)
+                .current_dir(&boehm_src)
+        });
+
+        env::set_current_dir(&boehm_src).unwrap();
+
+        run("./autogen.sh", |cmd| cmd);
+        run("./configure", |cmd| {
+            cmd.arg("--enable-static")
+                .arg("--disable-shared")
+                .env("CFLAGS", format!("{} {}", POINTER_MASK, FPIC))
+        });
+
+        // FIXME: Work out how to get [build-dependencies] working inside rustc
+        // so that this can be host specific.
+        let cpus = 1;
+        run("make", |cmd| cmd.arg("-j").arg(format!("{}", cpus)));
+    }
+
+    let mut libpath = PathBuf::from(&boehm_src);
+    libpath.push(BUILD_DIR);
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        &libpath.as_path().to_str().unwrap()
+    );
+    println!("cargo:rustc-link-lib=static=gc");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,168 @@
+//! This library acts as a shim to prevent static linking the Boehm GC directly
+//! inside library/alloc which causes surprising and hard to debug errors.
+
+#![no_std]
+#![feature(rustc_private)]
+#![feature(allocator_api)]
+#![feature(nonnull_slice_from_raw_parts)]
+
+use core::{
+    alloc::{AllocError, Allocator, GlobalAlloc, Layout},
+    ptr::NonNull,
+};
+
+pub struct BoehmGlobalAllocator;
+pub struct BoehmGcAllocator;
+
+unsafe impl GlobalAlloc for BoehmGlobalAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        #[cfg(feature = "rustc_boehm")]
+        return GC_malloc(layout.size()) as *mut u8;
+        #[cfg(not(feature = "rustc_boehm"))]
+        return GC_malloc_uncollectable(layout.size()) as *mut u8;
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
+        GC_free(ptr);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, _: Layout, new_size: usize) -> *mut u8 {
+        GC_realloc(ptr, new_size) as *mut u8
+    }
+}
+
+unsafe impl Allocator for BoehmGcAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = unsafe { GC_malloc(layout.size()) } as *mut u8;
+        assert!(!ptr.is_null());
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    unsafe fn deallocate(&self, _: NonNull<u8>, _: Layout) {}
+}
+
+impl BoehmGcAllocator {
+    pub fn force_gc() {
+        unsafe { GC_gcollect() }
+    }
+
+    pub unsafe fn register_finalizer(
+        &self,
+        obj: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    ) {
+        GC_register_finalizer_no_order(obj, finalizer, client_data, old_finalizer, old_client_data)
+    }
+
+    pub fn unregister_finalizer(&self, gcbox: *mut u8) {
+        unsafe {
+            GC_register_finalizer(
+                gcbox,
+                None,
+                ::core::ptr::null_mut(),
+                ::core::ptr::null_mut(),
+                ::core::ptr::null_mut(),
+            );
+        }
+    }
+
+    pub fn get_stats() -> BoehmStats {
+        let mut ps = ProfileStats::default();
+        unsafe {
+            GC_get_prof_stats(
+                &mut ps as *mut ProfileStats,
+                core::mem::size_of::<ProfileStats>(),
+            );
+        }
+        let total_gc_time = unsafe { GC_get_full_gc_total_time() };
+
+        BoehmStats {
+            total_gc_time,
+            num_collections: ps.gc_no,
+            total_freed: ps.bytes_reclaimed_since_gc,
+            total_alloced: ps.bytes_allocd_since_gc,
+        }
+    }
+
+    pub fn init() {
+        unsafe { GC_start_performance_measurement() };
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct ProfileStats {
+    /// Heap size in bytes (including area unmapped to OS).
+    pub(crate) heapsize_full: usize,
+    /// Total bytes contained in free and unmapped blocks.
+    pub(crate) free_bytes_full: usize,
+    /// Amount of memory unmapped to OS.
+    pub(crate) unmapped_bytes: usize,
+    /// Number of bytes allocated since the recent collection.
+    pub(crate) bytes_allocd_since_gc: usize,
+    /// Number of bytes allocated before the recent collection.
+    /// The value may wrap.
+    pub(crate) allocd_bytes_before_gc: usize,
+    /// Number of bytes not considered candidates for garbage collection.
+    pub(crate) non_gc_bytes: usize,
+    /// Garbage collection cycle number.
+    /// The value may wrap.
+    pub(crate) gc_no: usize,
+    /// Number of marker threads (excluding the initiating one).
+    pub(crate) markers_m1: usize,
+    /// Approximate number of reclaimed bytes after recent collection.
+    pub(crate) bytes_reclaimed_since_gc: usize,
+    /// Approximate number of bytes reclaimed before the recent collection.
+    /// The value may wrap.
+    pub(crate) reclaimed_bytes_before_gc: usize,
+    /// Number of bytes freed explicitly since the recent GC.
+    pub(crate) expl_freed_bytes_since_gc: usize,
+}
+
+pub struct BoehmStats {
+    pub total_gc_time: usize, // In milliseconds.
+    pub num_collections: usize,
+    pub total_freed: usize,   // In bytes
+    pub total_alloced: usize, // In bytes
+}
+
+#[link(name = "gc")]
+extern "C" {
+    fn GC_malloc(nbytes: usize) -> *mut u8;
+
+    #[cfg(not(feature = "rustc_boehm"))]
+    fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
+
+    fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
+
+    fn GC_free(dead: *mut u8);
+
+    fn GC_register_finalizer(
+        ptr: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    );
+
+    fn GC_register_finalizer_no_order(
+        ptr: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    );
+
+    fn GC_gcollect();
+
+    fn GC_start_performance_measurement();
+
+    fn GC_get_full_gc_total_time() -> usize;
+
+    fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
+
+}


### PR DESCRIPTION
In rboehm, the user can opt-in to compiling with the rustc_boehm fork -
which provides optimisations which need compiler support. This made
allocator linkage rather complicated: both rboehm and rustc_boehm had
implementations of the Boehm allocator, which were conditionally linked
based on which features were enabled.  In addition to being a source of
confusion, this meant that boehm allocator changes would need to be
duplicated and manually kept in-sync.

Previous attempts to link this as a separate crate failed because of a
dependency chicken-egg problem when adding it to the core library's dep
tree. However, I've recently discovered rustc-std-workspace-core[1] - a
hack that rustc uses to solve this exact issue.

[1]: https://crates.io/crates/rustc-std-workspace-core