### PR TITLE
Specialized allocation

### DIFF
--- a/.buildbot.config.toml
+++ b/.buildbot.config.toml
@@ -1,0 +1,17 @@
+# Config file for continuous integration.
+
+[rust]
+codegen-units = 0           # Use many compilation units.
+debug-assertions = true     # Turn on assertions in rustc.
+
+[build]
+docs = false
+extended = false
+
+[llvm]
+assertions = true           # Turn on assertions in LLVM.
+use-linker = "gold"         # Uses less memory than ld.
+
+[install]
+prefix = "build/rustc_boehm"
+sysconfdir = "etc"

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -12,7 +12,19 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu \
     --profile minimal \
     -y
 export PATH=`pwd`/.cargo/bin/:$PATH
-cargo check
 
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo +nightly fmt --all -- --check
+
+cargo +nightly test
+
+# Test rustgc features
+
+git clone https://github.com/softdevteam/rustgc
+mkdir -p rustgc/build/rustgc
+(cd rustgc && ./x.py build --config ../.buildbot.config.toml)
+
+rustup toolchain link rustgc rustgc/build/x86_64-unknown-linux-gnu/stage1
+
+cargo clean
+cargo +rustgc test --features "rustgc_internal" -- --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,26 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [lib]
-test = false
 bench = false
 doc = false
 
 [features]
 # Enable this feature to turn on additional GC optimizations that are only
 # possible with the rustgc fork of the compiler.
-rustgc = ["core", "compiler_builtins"]
+rustgc = ["core", "compiler_builtins", "rustgc_internal"]
+
+# The rustgc feature pulls in the "core" crate. This crate is a necessary hack
+# so that libgc_internal can be included in rustc-std when rustgc depends on it.
+#
+# Unfortunately, the "core" crate prevents libgc_internal from being compiled in
+# any other context - even cfg(test). Thus, in order to test the code for the
+# "rustgc" feature, we have to de-couple conditional compilation from the
+# dependencies that are added by the feature gate. As of cargo 1.50, it's not
+# possible to exclude dependencies based on cfg(test). A hack to get around this
+# is to use only rustgc_internal when conditionally compiling the relevant
+# sources, and including it as part of the rustgc feature. This way, `--features
+# rustgc_internal` can be used to test rustgc features.
+rustgc_internal = []
 
 # Enable various GC based statistics. Stats are disabled by default as they have
 # a run-time cost and are expected to only be used for profiling purposes.

--- a/src/boehm.rs
+++ b/src/boehm.rs
@@ -1,0 +1,50 @@
+// Needed to avoid linking to gc twice. When rustgc is enabled, the test target
+// will be built with a compiler already linked against libgc_internal. This
+// stops duplicate symbol errors.
+#![cfg_attr(not(all(test, feature = "rustgc_internal")), link(name = "gc"))]
+extern "C" {
+    pub(crate) fn GC_malloc(nbytes: usize) -> *mut u8;
+
+    #[cfg(not(feature = "rustgc_internal"))]
+    pub(crate) fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
+
+    pub(crate) fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
+
+    pub(crate) fn GC_free(dead: *mut u8);
+
+    pub(crate) fn GC_register_finalizer(
+        ptr: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    );
+
+    pub(crate) fn GC_register_finalizer_no_order(
+        ptr: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    );
+
+    pub(crate) fn GC_gcollect();
+
+    pub(crate) fn GC_start_performance_measurement();
+
+    pub(crate) fn GC_get_full_gc_total_time() -> usize;
+
+    pub(crate) fn GC_get_prof_stats(
+        prof_stats: *mut crate::ProfileStats,
+        stats_size: usize,
+    ) -> usize;
+
+    #[cfg(feature = "rustgc_internal")]
+    pub(crate) fn GC_malloc_explicitly_typed(size: usize, descriptor: usize) -> *mut u8;
+
+    #[cfg(feature = "rustgc_internal")]
+    pub(crate) fn GC_make_descriptor(bitmap: *const usize, len: usize) -> usize;
+
+    #[cfg(feature = "rustgc_internal")]
+    pub(crate) fn GC_malloc_atomic(nbytes: usize) -> *mut u8;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,9 @@ use core::{
     ptr::NonNull,
 };
 
-pub struct GlobalAllocator;
 pub struct GcAllocator;
 
-unsafe impl GlobalAlloc for GlobalAllocator {
+unsafe impl GlobalAlloc for GcAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         #[cfg(feature = "rustgc")]
         return GC_malloc(layout.size()) as *mut u8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ pub struct GcAllocator;
 
 unsafe impl GlobalAlloc for GcAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        #[cfg(feature = "rustgc")]
+        #[cfg(feature = "rustgc_internal")]
         return GC_malloc(layout.size()) as *mut u8;
-        #[cfg(not(feature = "rustgc"))]
+        #[cfg(not(feature = "rustgc_internal"))]
         return GC_malloc_uncollectable(layout.size()) as *mut u8;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 #![feature(rustc_private)]
 #![feature(allocator_api)]
 #![feature(nonnull_slice_from_raw_parts)]
+#![cfg_attr(feature = "rustgc_internal", feature(gc))]
+#![feature(specialization)]
+#![feature(negative_impls)]
+#![allow(incomplete_features)]
 
 use core::{
     alloc::{AllocError, Allocator, GlobalAlloc, Layout},
@@ -13,26 +17,30 @@ use core::{
 
 pub struct GcAllocator;
 
+mod boehm;
+#[cfg(feature = "rustgc_internal")]
+mod specializer;
+
 unsafe impl GlobalAlloc for GcAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         #[cfg(feature = "rustgc_internal")]
-        return GC_malloc(layout.size()) as *mut u8;
+        return boehm::GC_malloc(layout.size()) as *mut u8;
         #[cfg(not(feature = "rustgc_internal"))]
-        return GC_malloc_uncollectable(layout.size()) as *mut u8;
+        return boehm::GC_malloc_uncollectable(layout.size()) as *mut u8;
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
-        GC_free(ptr);
+        boehm::GC_free(ptr);
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, _: Layout, new_size: usize) -> *mut u8 {
-        GC_realloc(ptr, new_size) as *mut u8
+        boehm::GC_realloc(ptr, new_size) as *mut u8
     }
 }
 
 unsafe impl Allocator for GcAllocator {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let ptr = unsafe { GC_malloc(layout.size()) } as *mut u8;
+        let ptr = unsafe { boehm::GC_malloc(layout.size()) } as *mut u8;
         assert!(!ptr.is_null());
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
         Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
@@ -42,8 +50,14 @@ unsafe impl Allocator for GcAllocator {
 }
 
 impl GcAllocator {
+    #[cfg(feature = "rustgc_internal")]
+    pub fn maybe_optimised_alloc<T>(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let sp = specializer::AllocationSpecializer::new();
+        sp.maybe_optimised_alloc::<T>(layout)
+    }
+
     pub fn force_gc() {
-        unsafe { GC_gcollect() }
+        unsafe { boehm::GC_gcollect() }
     }
 
     pub unsafe fn register_finalizer(
@@ -54,12 +68,18 @@ impl GcAllocator {
         old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
         old_client_data: *mut *mut u8,
     ) {
-        GC_register_finalizer_no_order(obj, finalizer, client_data, old_finalizer, old_client_data)
+        boehm::GC_register_finalizer_no_order(
+            obj,
+            finalizer,
+            client_data,
+            old_finalizer,
+            old_client_data,
+        )
     }
 
     pub fn unregister_finalizer(&self, gcbox: *mut u8) {
         unsafe {
-            GC_register_finalizer(
+            boehm::GC_register_finalizer(
                 gcbox,
                 None,
                 ::core::ptr::null_mut(),
@@ -72,12 +92,12 @@ impl GcAllocator {
     pub fn get_stats() -> GcStats {
         let mut ps = ProfileStats::default();
         unsafe {
-            GC_get_prof_stats(
+            boehm::GC_get_prof_stats(
                 &mut ps as *mut ProfileStats,
                 core::mem::size_of::<ProfileStats>(),
             );
         }
-        let total_gc_time = unsafe { GC_get_full_gc_total_time() };
+        let total_gc_time = unsafe { boehm::GC_get_full_gc_total_time() };
 
         GcStats {
             total_gc_time,
@@ -88,7 +108,7 @@ impl GcAllocator {
     }
 
     pub fn init() {
-        unsafe { GC_start_performance_measurement() };
+        unsafe { boehm::GC_start_performance_measurement() };
     }
 }
 
@@ -128,41 +148,4 @@ pub struct GcStats {
     num_collections: usize,
     total_freed: usize,   // In bytes
     total_alloced: usize, // In bytes
-}
-
-#[link(name = "gc")]
-extern "C" {
-    fn GC_malloc(nbytes: usize) -> *mut u8;
-
-    #[cfg(not(feature = "rustgc"))]
-    fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
-
-    fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
-
-    fn GC_free(dead: *mut u8);
-
-    fn GC_register_finalizer(
-        ptr: *mut u8,
-        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
-        client_data: *mut u8,
-        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
-        old_client_data: *mut *mut u8,
-    );
-
-    fn GC_register_finalizer_no_order(
-        ptr: *mut u8,
-        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
-        client_data: *mut u8,
-        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
-        old_client_data: *mut *mut u8,
-    );
-
-    fn GC_gcollect();
-
-    fn GC_start_performance_measurement();
-
-    fn GC_get_full_gc_total_time() -> usize;
-
-    fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
-
 }

--- a/src/specializer.rs
+++ b/src/specializer.rs
@@ -1,0 +1,244 @@
+//! The contents of this module require the rustgc feature. To avoid polluting
+//! lib.rs with conditional compilation attributes, it is only exported if the
+//! rustgc feature is enabled.
+use core::{
+    alloc::{AllocError, Layout},
+    gc::{Conservative, NoTrace},
+    marker::PhantomData,
+    ptr::NonNull,
+};
+
+#[cfg(test)]
+use core::cell::Cell;
+
+use crate::boehm;
+
+/// An allocation helper to potentially optimise the marking of allocated
+/// blocks.
+///
+/// Allocation which is done through this bottleneck will try to use type
+/// information to allocate blocks in pools which are better optimised for
+/// marking. Allocation is a hot path, so to reduce branching at runtime, it
+/// makes heavy use of specialization, hence the name. Specialized allocation
+/// can be thought of as "compile-time cascading if-else".
+///
+/// There are three ways a block can be allocated:
+///
+///    Atomically - this means that a block contains no pointers which need
+///    tracing during marking. An atomically allocated block is a leaf node in
+///    the object graph.
+///
+///    Precisely - blocks are allocated along with a bitmap which describes
+///    where the pointers are on a per-word basis. The parts of a block which
+///    are not described in the bitmap are ignored by the collector during
+///    marking.
+///
+///    Conservatively - the whereabouts of pointers inside the block are
+///    unknown, and each word in the block must be considered for potential
+///    pointers.
+///
+/// There is a direct trade-off between the safety and performance of these
+/// three allocation types: atomic allocation will have the fastest marking
+/// times, but is the most dangerous; whereas conservative allocation is safe to
+/// use anywhere, but will have the slowest marking times.
+///
+/// This approach, however, only works when an allocation block corresponds to
+/// the layout of a single type. This isn't always the case (hence, the
+/// allocator_api operates on a Layout, which deliberately carries less
+/// information than a type parameter). For example, it's perfectly legal in
+/// Rust to allocate a chunk of memory, and use it to store values of type X, Y,
+/// and Z contiguously (provided size and alignment constraints are met).
+/// Conservative allocation is currently the only safe way to allocate such
+/// blocks.
+#[cfg(test)]
+pub(crate) struct AllocationSpecializer {
+    num_atomic: Cell<usize>,
+    num_precise: Cell<usize>,
+    num_conservative: Cell<usize>,
+}
+
+#[cfg(not(test))]
+pub(crate) struct AllocationSpecializer;
+
+impl AllocationSpecializer {
+    #[cfg(test)]
+    pub(crate) fn new() -> Self {
+        Self {
+            num_atomic: Cell::new(0),
+            num_precise: Cell::new(0),
+            num_conservative: Cell::new(0),
+        }
+    }
+
+    #[cfg(not(test))]
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    #[inline]
+    pub(crate) fn maybe_optimised_alloc<T>(
+        &self,
+        layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        ConservativeSpecializer::<T>::maybe_optimised_alloc(self, layout)
+    }
+
+    /// Allocates a block of memory for `layout` which is guaranteed to contains
+    /// no GC pointers.
+    ///
+    /// An atomic allocation has the same semantics as regular `alloc` except
+    /// for one key difference which is that it tells the collector not to trace
+    /// this block during marking.
+    ///
+    /// # Safety
+    ///
+    /// The block must not contain any pointers which, either directly or
+    /// transitively, point to a GC'd value.
+    unsafe fn atomic_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = boehm::GC_malloc_atomic(layout.size()) as *mut u8;
+        let ptr = NonNull::new_unchecked(ptr);
+        #[cfg(test)]
+        {
+            self.num_atomic.set(self.num_atomic.get() + 1);
+        }
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    /// Allocates a block of memory for `layout` where word-aligned fields are
+    /// described to the collector by `bitmap`.
+    ///
+    /// An atomic allocation has the same semantics as regular `alloc` except
+    /// for one key difference which is that it tells the collector not to trace
+    /// this block during marking.
+    ///
+    /// # Safety
+    ///
+    /// The size described by `layout` must be no larger than 4092 bytes.
+    ///
+    /// An incorrect `bitmap` will lead to undefined behaviour.
+    ///
+    /// The size described by `layout` must be at least as big as
+    /// `size_of::<usize> * bitmap_size`.
+    ///
+    /// The returned pointer must not be passed to `realloc` under any
+    /// circumstances.
+    unsafe fn precise_alloc(
+        &self,
+        layout: Layout,
+        bitmap: u64,
+        bitmap_size: u64,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let gc_descr =
+            boehm::GC_make_descriptor(&bitmap as *const u64 as *const usize, bitmap_size as usize);
+        let ptr = boehm::GC_malloc_explicitly_typed(layout.size(), gc_descr);
+        let ptr = NonNull::new_unchecked(ptr);
+        #[cfg(test)]
+        {
+            self.num_precise.set(self.num_precise.get() + 1);
+        }
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    /// Allocates a block of memory for `layout` which is traced conservatively
+    /// by the collector during marking.
+    fn conservative_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = unsafe { boehm::GC_malloc(layout.size()) } as *mut u8;
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        #[cfg(test)]
+        {
+            self.num_conservative.set(self.num_conservative.get() + 1);
+        }
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+}
+
+/// Specializes allocation for `T` based on its impl of the `Conservative` trait.
+///
+/// The implementation of `T: Conservative` will bypass all other allocation
+/// strategies and guarantee that the block required by `layout` is allocated
+/// conservatively.
+trait ConservativeSpecializer<T> {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError>;
+}
+
+impl<T> ConservativeSpecializer<T> for AllocationSpecializer {
+    default fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        AtomicSpecializer::<T>::maybe_optimised_alloc(self, layout)
+    }
+}
+
+impl<T: Conservative> ConservativeSpecializer<T> for AllocationSpecializer {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        self.conservative_alloc(layout)
+    }
+}
+
+/// Specializes allocation for `T` based on its impl of the `NoTrace` trait.
+///
+/// The implementation of `T: NoTrace` guarantees (provided that `T:
+/// !Conservative`) that the block required by `layout` is allocated atomically.
+trait AtomicSpecializer<T> {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError>;
+}
+
+impl<T> AtomicSpecializer<T> for AllocationSpecializer {
+    default fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let trace = unsafe { ::core::gc::gc_layout::<T>() };
+        if trace.must_use_conservative() {
+            return self.conservative_alloc(layout);
+        }
+        unsafe { self.precise_alloc(layout, trace.bitmap, trace.size) }
+    }
+}
+
+impl<T: NoTrace> AtomicSpecializer<T> for AllocationSpecializer {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        unsafe { self.atomic_alloc(layout) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_alloc() {
+        struct T(usize);
+        impl NoTrace for T {}
+
+        struct U(usize);
+        impl !NoTrace for U {}
+
+        let sp = AllocationSpecializer::new();
+
+        sp.maybe_optimised_alloc::<T>(Layout::new::<T>());
+        assert_eq!(sp.num_atomic.get(), 1);
+
+        sp.maybe_optimised_alloc::<U>(Layout::new::<U>());
+        assert_eq!(sp.num_atomic.get(), 1);
+    }
+
+    #[test]
+    fn conservative_alloc() {
+        struct T(usize);
+
+        impl NoTrace for T {}
+        impl Conservative for T {}
+
+        let sp = AllocationSpecializer::new();
+
+        sp.maybe_optimised_alloc::<T>(Layout::new::<T>());
+        assert_eq!(sp.num_conservative.get(), 1);
+    }
+
+    #[test]
+    fn precise_alloc() {
+        struct T(usize);
+
+        impl !NoTrace for T {}
+
+        let sp = AllocationSpecializer::new();
+        sp.maybe_optimised_alloc::<T>(Layout::new::<T>());
+        assert_eq!(sp.num_precise.get(), 1);
+    }
+}


### PR DESCRIPTION
There are three ways a block can be allocated:

- Atomically - this means that a block contains no pointers which need
tracing during marking. An atomically allocated block is a leaf node in
the object graph.
 
- Precisely - blocks are allocated along with a bitmap which describes
where the pointers are on a per-word basis. The parts of a block which
are not described in the bitmap are ignored by the collector during
marking.
 
- Conservatively - the whereabouts of pointers inside the block are
unknown, and each word in the block must be considered for potential
pointers.

Users who enable the rustgc feature can now allocate memory with
`GcAllocator::maybe_optimised_alloc`. This method tries to allocate
blocks precisely (or even atomically) based on a value's type.  It first
tries to specialize allocation based on whether a type implements the
`Conservative` or `NoTrace` traits, and then uses the `gc_layout`
intrinsic in rustgc to try to allocate a block with a precise layout.