### PR TITLE
Add specialized alloc methods to GlobalAlloc trait

### DIFF
--- a/src/specializer.rs
+++ b/src/specializer.rs
@@ -11,7 +11,9 @@ use core::{
 #[cfg(test)]
 use core::cell::Cell;
 
+use crate::ALLOCATOR;
 use crate::boehm;
+
 
 /// An allocation helper to potentially optimise the marking of allocated
 /// blocks.


### PR DESCRIPTION
https://github.com/softdevteam/rustgc/pull/23/ updates the `GlobalAlloc` trait to include different allocation strategies. This PR implements them.